### PR TITLE
Go faster!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-O3 -fopenmp -Wall -Wextra -lX11
+CFLAGS=-O3 -march=native -fopenmp -Wall -Wextra -lX11
 
 i3lock-fancy-rapid: i3lock-fancy-rapid.c
 	$(CC) $^ $(CFLAGS) -o $@


### PR DESCRIPTION
  * Get better cache performance, especially for more iterations
  * use -march=native for newer SIMD instructions

Can run with radius 10, 1000 iterations in 5.9s, compared to 10.4