### PR TITLE
removed malloc.h due to it's already included with stdlib.h

### DIFF
--- a/i3lock-fancy-rapid.c
+++ b/i3lock-fancy-rapid.c
@@ -32,7 +32,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <malloc.h>
 #include <unistd.h>
 #include <sys/wait.h>
 #include <X11/Xlib.h>
@@ -41,8 +40,7 @@
 #include <string.h>
 
 void box_blur_h(unsigned char *dest, unsigned char *src, int height, int width,
-                int radius)
-{
+                int radius) {
     double coeff = 1.0 / (radius * 2 + 1);
 #pragma omp parallel for
     for (int i = 0; i < height; ++i) {
@@ -80,15 +78,14 @@ static inline void transpose(unsigned char *dest, unsigned char *src, int height
             int nIndex = 3 * (iwidth + j);
             int tIndex = 3 * (j * height + i);
             dest[tIndex] = src[nIndex];
-            dest[tIndex+1] = src[nIndex+1];
-            dest[tIndex+2] = src[nIndex+2];
+            dest[tIndex + 1] = src[nIndex + 1];
+            dest[tIndex + 2] = src[nIndex + 2];
         }
     }
 }
 
 void box_blur(unsigned char *dest, unsigned char *src, int height, int width,
-              int radius, int times)
-{
+              int radius, int times) {
     for (int i = 0; i < times; ++i) {
         box_blur_h(dest, src, height, width, radius);
         memcpy(src, dest, height * width * 3);
@@ -102,8 +99,7 @@ void box_blur(unsigned char *dest, unsigned char *src, int height, int width,
 }
 
 void pixelate(unsigned char *dest, unsigned char *src, int height,
-                   int width, int radius)
-{
+              int width, int radius) {
     radius = radius * 2 + 1;
 #pragma omp parallel for
     for (int i = 0; i < height; i += radius) {
@@ -151,13 +147,12 @@ void pixelate(unsigned char *dest, unsigned char *src, int height,
     }
 }
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
     if (argc < 3) {
         fprintf(stderr,
-               "usage: %s radius times [OPTIONS]\n"
-               "pass \"pixel\" for times to get pixelation\n",
-               argv[0]);
+                "usage: %s radius times [OPTIONS]\n"
+                "pass \"pixel\" for times to get pixelation\n",
+                argv[0]);
         exit(EXIT_FAILURE);
     }
 

--- a/i3lock-fancy-rapid.c
+++ b/i3lock-fancy-rapid.c
@@ -52,6 +52,18 @@ int main(int argc, char *argv[]) {
         exit(EXIT_FAILURE);
     }
 
+    int radius = atoi(argv[1]);
+    if (radius < 0) {
+        fprintf(stderr, "Radius has to be non-negative!\n");
+        exit(EXIT_FAILURE);
+    }
+
+    int times = atoi(argv[2]);
+    if (times < 0) {
+        fprintf(stderr, "Times has to be non-negative!\n");
+        exit(EXIT_FAILURE);
+    }
+
     Display *display = XOpenDisplay(NULL);
     Window root = XDefaultRootWindow(display);
     XWindowAttributes gwa;
@@ -59,8 +71,7 @@ int main(int argc, char *argv[]) {
     int height = gwa.height;
     int width = gwa.width;
     unsigned char *preblur = malloc(height * width * 3);
-    XImage *image = XGetImage(display, root, 0, 0, width, height, AllPlanes,
-                              ZPixmap);
+    XImage *image = XGetImage(display, root, 0, 0, width, height, AllPlanes, ZPixmap);
     for (int i = 0; i < height; ++i) {
         int iwidth = i * width;
         for (int j = 0; j < width; ++j) {
@@ -76,19 +87,9 @@ int main(int argc, char *argv[]) {
     XCloseDisplay(display);
 
     unsigned char *postblur = malloc(height * width * 3);
-    int radius = atoi(argv[1]);
-    if (radius < 0) {
-        fprintf(stderr, "Radius has to be non-negative!\n");
-        exit(EXIT_FAILURE);
-    }
     if (strcmp(argv[2], "pixel") == 0) {
         pixelate(postblur, preblur, height, width, radius);
     } else {
-        int times = atoi(argv[2]);
-        if (times < 0) {
-            fprintf(stderr, "Times has to be non-negative!\n");
-            exit(EXIT_FAILURE);
-        }
         box_blur(postblur, preblur, height, width, radius, times);
     }
     free(preblur);

--- a/i3lock-fancy-rapid.h
+++ b/i3lock-fancy-rapid.h
@@ -1,0 +1,10 @@
+#ifndef I3LOCK_FANCY_RAPID_I3LOCK_FANCY_RAPID_C_H
+#define I3LOCK_FANCY_RAPID_I3LOCK_FANCY_RAPID_C_H
+
+void box_blur_h(unsigned char *dest, unsigned char *src, int height, int width, int radius);
+
+void box_blur(unsigned char *dest, unsigned char *src, int height, int width, int radius, int times);
+
+void pixelate(unsigned char *dest, unsigned char *src, int height, int width, int radius);
+
+#endif //I3LOCK_FANCY_RAPID_I3LOCK_FANCY_RAPID_C_H


### PR DESCRIPTION
> The <malloc.h> header is deprecated (and quite Linux specific, on which it defines non-standard functions like [mallinfo(3)](http://man7.org/linux/man-pages/man3/mallinfo.3.html)). Use <stdlib.h> instead if you simply need [malloc(3)](http://man7.org/linux/man-pages/man3/malloc.3.html) and related standard functions (e.g. free, calloc, realloc ....). Notice that <stdlib.h> is defined by [C89](https://en.wikipedia.org/wiki/C89) (and later) standards, but not <malloc.h>
_Source: https://stackoverflow.com/a/12973361_

And stdlib.h is already included, why I also suggest removing  the header. Besides removing the header, there is some reformatting of the code to make the code style more similar.

Also, I've moved the error handling to the beginning of the program to avoid unnecessary malloc allocation.